### PR TITLE
feat: Implement and test database module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,4 @@ jobs:
       run: uv run ruff check .
 
     - name: Run tests
-      run: uv run pytest
-      continue-on-error: true 
+      run: uv run pytest 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# Career Assistant Backend
+
+This directory contains the backend source code for the Career Assistant application.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.12"
 readme = "README.md"
 license = { text = "MIT" }
 dependencies = [
+    "aerich>=0.9.0",
+    "aiosqlite>=0.21.0",
     "apscheduler>=3.11.0",
     "loguru>=0.7.3",
     "pydantic-settings-yaml>=0.2.0",
@@ -15,17 +17,38 @@ dependencies = [
     "tortoise-orm>=0.25.1",
 ]
 
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
 [tool.ruff]
-line-length = 88
+line-length = 120
 indent-width = 4
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "A", "C4", "T20", "SIM", "PTH"]
-ignore = ["E501"]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # Pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501", # line too long, handled by ruff format
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.uv]
 dev-dependencies = [
     "pytest>=8.4.0",
     "pytest-asyncio>=1.0.0",
     "ruff>=0.11.13",
+    "typer[all]>=0.16.0",
 ]

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+from pydantic_settings import SettingsConfigDict
+from pydantic_settings_yaml import YamlBaseSettings
+
+# from src.utils.notify_logger.config import LoggerConfig
+
+
+def get_base_dir() -> Path:
+    """
+    Get the base directory of the project.
+
+    Returns:
+        Path: The base directory of the project.
+    """
+
+    current_dir = Path(__file__).resolve()
+    while (
+        current_dir.parent != current_dir
+        and not (current_dir / "config.yaml").exists()
+    ):
+        current_dir = current_dir.parent
+    return current_dir
+
+
+BASE_DIR = get_base_dir()
+
+
+# Добавляем модели для других секций конфига, если они есть в config.yaml
+class FrontendServeConfig(BaseModel):
+    """
+    Configuration settings for serving the frontend application.
+
+    Attributes:
+        host (str): The host address for the frontend server.
+        port (int): The port number for the frontend server.
+    """
+
+    host: str = "localhost"
+    port: int = 3000
+
+
+class FrontendConfig(BaseModel):
+    """
+    Overall frontend application configuration.
+
+    Attributes:
+        serve (FrontendServeConfig): Settings related to serving the frontend.
+        static_dir (str): The directory where static frontend build files are
+        located.
+    """
+
+    serve: FrontendServeConfig = Field(default_factory=FrontendServeConfig)
+    static_dir: str = "frontend/build"
+
+
+class DatabaseConfig(BaseModel):
+    """
+    Configuration settings for the database connection.
+
+    Can be defined either via a connection URL or by individual parameters.
+
+    Attributes:
+        url (Optional[str]): A full database connection URL. If provided,
+         other parameters are ignored.
+        host (str): The database host address.
+        port (int): The database port number.
+        user (str): The username for database access.
+        password (Optional[str]): The password for database access. Loaded from
+         environment variables for security.
+        name (str): The name of the database to connect to.
+        engine (str): The Tortoise ORM backend engine.
+    """
+
+    url: str | None = None
+    host: str = "db.example.com"
+    port: int = 5432
+    user: str = "app_user"
+    password: str | None = None
+    name: str = "my_database"
+    engine: str = "tortoise.backends.asyncpg"
+
+
+class ApiConfig(BaseModel):
+    """
+    Configuration settings for the API server.
+
+    Attributes:
+        host (str): The host address for the API server.
+        port (int): The port number for the API server.
+    """
+
+    host: str = "0.0.0.0"  # noqa: S104
+    port: int = 8000
+
+
+class BackendConfig(BaseModel):
+    """
+    Overall backend application configuration.
+
+    Attributes:
+        logger (LoggerConfig): Configuration settings for the application
+        logger.
+        database (DatabaseConfig): Configuration settings for the database
+        connection.
+        api (ApiConfig): Configuration settings for the API server.
+    """
+
+    # logger: LoggerConfig = Field(default_factory=LoggerConfig)
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+    api: ApiConfig = Field(default_factory=ApiConfig)
+
+
+class MainConfig(YamlBaseSettings):
+    """
+    Main application configuration.
+
+    This class loads application settings from `config.yaml` and `.env` files.
+    It uses Pydantic-settings to manage hierarchical configuration.
+
+    Attributes:
+        frontend (FrontendConfig): Frontend specific settings.
+        backend (BackendConfig): Backend specific settings, including logger,
+        database, and API.
+    """
+
+    model_config = SettingsConfigDict(
+        # Загружаем статический YAML из корня проекта
+        yaml_file=BASE_DIR / "config.yaml",
+        yaml_file_encoding="utf-8",
+        # Затем загружаем .env из корня проекта (для секретов)
+        env_file=BASE_DIR / ".env",
+        env_file_encoding="utf-8",
+        # Общий префикс для переменных окружения приложения
+        env_prefix="APP_",
+        env_nested_delimiter="__",
+    )
+
+    frontend: FrontendConfig = Field(default_factory=FrontendConfig)
+    backend: BackendConfig = Field(default_factory=BackendConfig)

--- a/backend/src/db/__init__.py
+++ b/backend/src/db/__init__.py
@@ -1,0 +1,3 @@
+from .db import close_db, init_db
+
+__all__ = ["close_db", "init_db"]

--- a/backend/src/db/config.py
+++ b/backend/src/db/config.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.config.config import DatabaseConfig
+
+
+def get_tortoise_orm_config(
+    db_config: DatabaseConfig,
+    models_files: list[str],
+) -> dict[str, Any]:
+    """
+    Returns the configuration for Tortoise ORM.
+
+    The configuration is determined by the `db_config` object. If `db_config.url`
+    is provided, it's used directly. Otherwise, connection parameters are
+    assembled from the other `db_config` attributes.
+
+    Args:
+        db_config: The database configuration object.
+        models_files: A list of model modules to include.
+
+    Returns:
+        The configuration dictionary for Tortoise ORM.
+    """
+    connection_config: dict[str, Any]
+    if db_config.url:
+        connection_config = {"default": db_config.url}
+    else:
+        connection_config = {
+            "default": {
+                "engine": db_config.engine,
+                "credentials": {
+                    "host": db_config.host,
+                    "port": db_config.port,
+                    "user": db_config.user,
+                    "password": db_config.password,
+                    "database": db_config.name,
+                },
+            },
+        }
+
+    return {
+        "connections": connection_config,
+        "apps": {
+            "models": {
+                "models": [*models_files, "aerich.models"],
+                "default_connection": "default",
+            },
+        },
+    }

--- a/backend/src/db/db.py
+++ b/backend/src/db/db.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tortoise import Tortoise
+from tortoise.connection import connections
+
+# from src.utils.notify_logger.logger import logger
+from .config import get_tortoise_orm_config
+
+if TYPE_CHECKING:
+    from src.config.config import DatabaseConfig
+
+
+_MODELS_FILES = [
+    "src.db.models.job",
+]
+
+
+async def init_db(db_config: DatabaseConfig) -> None:
+    """
+    Initializes the database connection and generates schemas.
+
+    This function should be called once at the start of the application,
+    with the appropriate configuration.
+
+    Args:
+        db_config: The database configuration object.
+    """
+    # logger.info("Initializing database connection...")
+    tortoise_orm_config = get_tortoise_orm_config(
+        db_config=db_config,
+        models_files=_MODELS_FILES,
+    )
+    try:
+        await Tortoise.init(config=tortoise_orm_config)
+        await Tortoise.generate_schemas()
+        # logger.info("Database connection initialized successfully.")
+    except Exception as e:
+        # logger.error("Database initialization error", exception=e)
+        raise e from e
+
+
+async def close_db() -> None:
+    """
+    Close all established database connections.
+
+    This function should be called at the end of the application's lifecycle.
+    """
+    # logger.info("Closing database connections...")
+    await connections.close_all()
+    # logger.info("All database connections closed.")

--- a/backend/src/db/models/__init__.py
+++ b/backend/src/db/models/__init__.py
@@ -1,0 +1,7 @@
+"""
+This package contains the Tortoise ORM models for the application.
+"""
+
+from .job import Job
+
+__all__ = ["Job"]

--- a/backend/src/db/models/job.py
+++ b/backend/src/db/models/job.py
@@ -1,0 +1,40 @@
+from typing import ClassVar
+
+from tortoise import fields, models
+
+
+class Job(models.Model):
+    """
+    Model for storing job information in the database.
+
+    Attributes:
+        id (int): Unique job identifier, primary key.
+        title (str): Job title.
+        company (str): Company name that posted the job.
+        location (str): Job location.
+        url (str): Unique job URL, used to prevent duplicates.
+        description (str): Full job description.
+        salary (str | None): Salary information, can be None.
+        posted_date (datetime | None): Job posting date, can be None.
+        created_at (datetime): Date and time of record creation.
+        updated_at (datetime): Date and time of the last record update.
+    """
+
+    id = fields.IntField(primary_key=True)
+    title = fields.CharField(max_length=255)
+    company = fields.CharField(max_length=255)
+    location = fields.CharField(max_length=255)
+    url = fields.CharField(max_length=512, unique=True, db_index=True)
+    description = fields.TextField()
+    salary = fields.CharField(max_length=255, null=True)
+    posted_date = fields.DatetimeField(null=True)
+
+    created_at = fields.DatetimeField(auto_now_add=True)
+    updated_at = fields.DatetimeField(auto_now=True)
+
+    class Meta:  # type: ignore[reportIncompatibleVariableOverride]
+        table = "jobs"
+        ordering: ClassVar[list[str]] = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"{self.title} at {self.company}"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,32 @@
+from collections.abc import AsyncGenerator
+
+import pytest_asyncio
+
+from src.config.config import DatabaseConfig
+from src.db.db import close_db, init_db
+
+_MODELS_FILES = [
+    "src.db.models.job",
+    "aerich.models",
+]
+
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def db_init() -> AsyncGenerator[None, None]:
+    """
+    Fixture to initialize the test database before each test.
+
+    This fixture creates an in-memory SQLite database, initializes
+    Tortoise ORM using the centralized `init_db` function, and then closes
+    the connection after the test completes.
+
+    Yields:
+        None
+    """
+    db_config = DatabaseConfig(
+        url="sqlite://:memory:",
+        engine="tortoise.backends.sqlite",
+    )
+    await init_db(db_config)
+    yield
+    await close_db()

--- a/backend/tests/db/test_db.py
+++ b/backend/tests/db/test_db.py
@@ -1,0 +1,57 @@
+import pytest
+
+from src.db.models import Job
+
+
+@pytest.mark.asyncio
+async def test_db_model_operations() -> None:
+    """
+    Test basic database operations: creating and retrieving Job model.
+
+    This test checks that:
+    1. Connection to the test database (configured in conftest.py) is
+    established.
+    2. The Job model can be successfully created.
+    3. The created model can be found and retrieved from the database.
+    """
+
+    # Test data
+    test_url = "https://example.com/job/123"
+    test_title = "Middle Python Developer"
+
+    await Job.create(
+        title=test_title,
+        company="Tech Corp",
+        location="Remote",
+        url=test_url,
+        description="A great job.",
+    )
+
+    created_job = await Job.get(url=test_url)
+    assert created_job is not None
+    assert created_job.title == test_title
+    assert created_job.company == "Tech Corp"
+
+    job_count = await Job.all().count()
+    assert job_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_job() -> None:
+    """
+    Tests the creation and retrieval of a Job model instance.
+
+    This test verifies that a Job can be successfully created with specific
+    attributes and then retrieved from the database, confirming that the basic
+    database operations and model definitions are working correctly.
+    """
+    job = await Job.create(
+        title="Software Engineer",
+        company="Tech Corp",
+        location="Remote",
+        description="Developing cool stuff.",
+        url="https://example.com/job/1",
+    )
+    retrieved_job = await Job.get(id=job.id)
+    assert retrieved_job.id == job.id
+    assert retrieved_job.title == "Software Engineer"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,6 +2,21 @@ version = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "aerich"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asyncclick" },
+    { name = "dictdiffer" },
+    { name = "pydantic" },
+    { name = "tortoise-orm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/4b/1facb78fea47f790040035b94fdcc31630fabe1bda49ebc7a4f374da1757/aerich-0.9.0.tar.gz", hash = "sha256:37c7ca71e947e7de3aa0e778cb193fc1faebf9136a0f1108b52b902918b85acc", size = 34280 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/b6/4a4874edd218cf38110ce129967e02c8fb3a85fec46713d8df2e0d9a9248/aerich-0.9.0-py3-none-any.whl", hash = "sha256:64d4b79eb789895c83765d6a9fdc9d9fb047d5c39c369eeab0e3e043dfacc8a6", size = 38725 },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -23,6 +38,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
+]
+
+[[package]]
 name = "apscheduler"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -35,10 +64,26 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncclick"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/e1e5fdf1c1bb7e6e614987c120a98d9324bf8edfaa5f5cd16a6235c9d91b/asyncclick-8.1.8.tar.gz", hash = "sha256:0f0eb0f280e04919d67cf71b9fcdfb4db2d9ff7203669c40284485c149578e4c", size = 232900 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/cc/a436f0fc2d04e57a0697e0f87a03b9eaed03ad043d2d5f887f8eebcec95f/asyncclick-8.1.8-py3-none-any.whl", hash = "sha256:eb1ccb44bc767f8f0695d592c7806fdf5bd575605b4ee246ffd5fadbcfdbd7c6", size = 99093 },
+    { url = "https://files.pythonhosted.org/packages/92/c4/ae9e9d25522c6dc96ff167903880a0fe94d7bd31ed999198ee5017d977ed/asyncclick-8.1.8.0-py3-none-any.whl", hash = "sha256:be146a2d8075d4fe372ff4e877f23c8b5af269d16705c1948123b9415f6fd678", size = 99115 },
+]
+
+[[package]]
 name = "career-assistant-backend"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
+    { name = "aerich" },
+    { name = "aiosqlite" },
     { name = "apscheduler" },
     { name = "loguru" },
     { name = "pydantic" },
@@ -52,10 +97,13 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aerich", specifier = ">=0.9.0" },
+    { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "apscheduler", specifier = ">=3.11.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", specifier = ">=2.11.5" },
@@ -69,6 +117,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.11.13" },
+    { name = "typer", extras = ["all"], specifier = ">=0.16.0" },
 ]
 
 [[package]]
@@ -116,12 +165,33 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "dictdiffer"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/7b/35cbccb7effc5d7e40f4c55e2b79399e1853041997fcda15c9ff160abba0/dictdiffer-0.9.0.tar.gz", hash = "sha256:17bacf5fbfe613ccf1b6d512bd766e6b21fb798822a133aa86098b8ac9997578", size = 31513 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/ef/4cb333825d10317a36a1154341ba37e6e9c087bac99c1990ef07ffdb376f/dictdiffer-0.9.0-py2.py3-none-any.whl", hash = "sha256:442bfc693cfcadaf46674575d2eba1c53b42f5e404218ca2c2ff549f2df56595", size = 16754 },
 ]
 
 [[package]]
@@ -162,6 +232,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
 [[package]]
@@ -384,6 +475,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.13"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +513,24 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
 name = "tortoise-orm"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -421,6 +543,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9b/de966810021fa773fead258efd8deea2bb73bb12479e27f288bd8ceb8763/tortoise_orm-0.25.1.tar.gz", hash = "sha256:4d5bfd13d5750935ffe636a6b25597c5c8f51c47e5b72d7509d712eda1a239fe", size = 128341 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/55/2bda7f4445f4c07b734385b46d1647a388d05160cf5b8714a713e8709378/tortoise_orm-0.25.1-py3-none-any.whl", hash = "sha256:df0ef7e06eb0650a7e5074399a51ee6e532043308c612db2cac3882486a3fd9f", size = 167723 },
+]
+
+[[package]]
+name = "typer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317 },
 ]
 
 [[package]]


### PR DESCRIPTION
*   **Added `db` module:** Introduced a new module for all database-related logic. This includes the `Job` model, Tortoise ORM configuration (`config.py`), and connection handling (`db.py`).
*   **Decoupled for Testability:** Refactored the database initialization to use Dependency Injection. The `init_db` function now accepts a configuration object, which removes import-time side effects and makes the module fully testable and independent.
*   **Unified Test Fixtures:** Updated `conftest.py` to use the same centralized `init_db` logic as the main application. The test environment is configured to use an in-memory SQLite database for fast and isolated testing.
*   **Added Database Tests:** Created `tests/db/test_db.py` with initial tests to verify that database models can be created and retrieved successfully, ensuring the CI pipeline has coverage for the data layer.