### PR TITLE
chore: Remove duplicate config.yaml

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,2 +1,0 @@
-database_url: sqlite://db.sqlite3
-telegram_bot_token: YOUR_TELEGRAM_BOT_TOKEN 


### PR DESCRIPTION
Removes the redundant configuration file from the backend directory to maintain a single source of truth in the root config.yaml.