### PR TITLE
chore(.gitignore): add Cursor dev files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,4 +152,10 @@ cython_debug/
 *.sln
 *.sw?
 
+# Cursor
+.cursor/
+architecture.md
+tasks.md
+*.code-workspace
+
 # Add any other rules or patterns as needed 


### PR DESCRIPTION
### Context

This PR improves repository hygiene by updating the `.gitignore` file to exclude files and directories specific to the Cursor editor. This prevents user-specific settings and auto-generated metadata from being committed to the repository, keeping the project history clean and avoiding potential conflicts for other contributors.

---

### Description of Changes

-   Modified the `.gitignore` file to ignore the following patterns related to Cursor:
    -   `.cursor/`
    -   `architecture.md`
    -   `tasks.md`
    -   `*.code-workspace`

---

### How to Test

This change does not affect application logic and doesn't require automated testing. Verification can be done manually:

1.  Inspect the `.gitignore` file to confirm the new rules have been added.
2.  Run `git status` in the project root. Files and directories matching the new patterns should no longer appear as "Untracked files".