### PR TITLE
refactor(repository): rename unused variable to _

### DIFF
--- a/backend/src/db/repository.py
+++ b/backend/src/db/repository.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pydantic import HttpUrl
-
-from src.core.schemas import JobSchema
 from src.db.models.job import Job
+
+if TYPE_CHECKING:
+    from pydantic import HttpUrl
+
+    from src.core.schemas import JobSchema
 
 
 class JobRepository:
@@ -63,7 +65,7 @@ class JobRepository:
         Updates an existing job or creates a new one based on the URL.
         """
         job_dict = job_schema.model_dump(mode="json", exclude_unset=True)
-        job, created = await Job.update_or_create(
-            defaults=job_dict, url=job_dict["url"]
+        job, _ = await Job.update_or_create(
+            defaults=job_dict, url=job_dict["url"],
         )
         return job


### PR DESCRIPTION
##Context
the code contained an unused variable needed for unpacking and requirements that are used only for type annotations.

##Description
1. rename unused variable to _ according to PEP 8.
2. move type requirements to "IF TYPE_CHECKING" block  to fix the ruff linter warning.

#How to test
No manual testing is required. A successful CI pipeline is sufficient for verification.