### PR TITLE
fix(config): correct loading priority and add tests

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,34 +2,22 @@
 name = "career_assistant_backend"
 version = "0.1.0"
 description = "Backend for the Career Assistant project."
-authors = [{ name = "Anton Zh", email = "anton.zhorin@gmail.com" }]
 requires-python = ">=3.12"
-readme = "README.md"
-license = { text = "MIT" }
-dependencies = [
-    "aerich>=0.9.0",
-    "aiosqlite>=0.21.0",
-    "apscheduler>=3.11.0",
-    "beautifulsoup4>=4.12.3",
-    "httpx>=0.27.0",
-    "loguru>=0.7.3",
-    "pydantic-settings-yaml>=0.2.0",
-    "pydantic>=2.11.5",
-    "pytelegrambotapi>=4.27.0",
-    "tortoise-orm>=0.25.1",
-    "lxml>=5.2.2",
-    "fastapi>=0.111.0",
-    "uvicorn[standard]>=0.30.1",
-]
+dependencies = ["aerich>=0.9.0", "aiosqlite>=0.21.0", "apscheduler>=3.11.0", "beautifulsoup4>=4.12.3", "httpx>=0.27.0", "loguru>=0.7.3", "pydantic>=2.11.5", "pytelegrambotapi>=4.27.0", "tortoise-orm>=0.25.1", "lxml>=5.2.2", "fastapi>=0.111.0", "uvicorn[standard]>=0.30.1", "tomlkit>=0.13.0", "asyncpg>=0.29.0", "pyyaml>=6.0.1"]
+
+[[project.authors]]
+name = "Anton Zh"
+email = "anton.zhorin@gmail.com"
+
+[project.license]
+text = "MIT"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q --cov=src --cov-report=html"
 testpaths = ["tests"]
 pythonpath = ["src"]
-markers = [
-    "unittest: for unit tests",
-]
+markers = ["unittest: for unit tests"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
@@ -39,29 +27,20 @@ line-length = 100
 indent-width = 4
 
 [tool.ruff.lint]
-select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # Pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
-]
-ignore = [
-    "E501", # line too long, handled by ruff format
-]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+ignore = ["E501"]
+
+[tool.uv]
+dev-dependencies = ["pytest>=8.4.0", "pytest-asyncio>=1.0.0", "pytest-cov>=5.0.0", "pytest-mock>=3.14.0", "ruff>=0.11.13", "typer[all]>=0.16.0"]
+
+[tool.aerich]
+tortoise_orm = "src.main.TORTOISE_ORM_CONFIG"
+location = "./migrations"
+src_folder = "./."
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = [
-    "pytest>=8.4.0",
-    "pytest-asyncio>=1.0.0",
-    "pytest-cov>=5.0.0",
-    "pytest-mock>=3.14.0",
-    "ruff>=0.11.13",
-    "typer[all]>=0.16.0",
-]
+[tool.poetry.group.dev.dependencies]
+# ... existing code ...

--- a/backend/src/config/__init__.py
+++ b/backend/src/config/__init__.py
@@ -1,6 +1,11 @@
+import os
 from functools import lru_cache
+from typing import Any
 
-from .config import MainConfig
+import yaml
+from dotenv import load_dotenv
+
+from .config import MainConfig, get_config_path
 
 
 @lru_cache
@@ -8,13 +13,62 @@ def get_main_config() -> MainConfig:
     """
     Returns a cached instance of the MainConfig settings.
 
-    Using lru_cache ensures that the settings are loaded from files
-    and environment variables only once.
+    It manually loads settings in a controlled order of priority:
+    1. Values from the YAML file.
+    2. Values from the .env file and other environment variables, which override YAML.
 
     Returns:
         MainConfig: The application's configuration settings.
     """
-    return MainConfig()
+    yaml_config = _load_yaml_config()
+    _override_from_env_file()
+    _override_from_env_variables(yaml_config)
+
+    return MainConfig.model_validate(yaml_config)
+
+
+def _load_yaml_config() -> dict[str, Any]:
+    """
+    Load the configuration from the YAML file.
+    """
+    yaml_path = get_config_path("config.yaml")
+    if not yaml_path.exists():
+        msg = f"Configuration file not found: {yaml_path}"
+        raise FileNotFoundError(msg)
+
+    with yaml_path.open(encoding="utf-8") as f:
+        config_data: dict[str, Any] = yaml.safe_load(f) or {}
+    return config_data
+
+
+def _override_from_env_file() -> None:
+    """
+    Override the config with environment variables from the .env file.
+    """
+    env_path = get_config_path(".env")
+    if env_path.exists():
+        load_dotenv(dotenv_path=env_path)
+
+
+def _override_from_env_variables(yaml_config: dict[str, Any]) -> None:
+    """
+    Override the config with environment variables.
+
+    Args:
+        yaml_config (dict[str, Any]): The base configuration dictionary.
+    """
+    for key, value in os.environ.items():
+        # Traverse the config dict using the '__' delimiter
+        keys = key.lower().split("__")
+        d = yaml_config
+        for k in keys[:-1]:
+            if k in d and isinstance(d.get(k), dict):
+                d = d[k]
+            else:
+                d = None
+                break
+        if d and keys[-1] in d:
+            d[keys[-1]] = value
 
 
 __all__ = ["get_main_config"]

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -1,30 +1,23 @@
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
-from pydantic_settings import SettingsConfigDict
-from pydantic_settings_yaml import YamlBaseSettings
 
 from src.utils.notify_logger.config import LoggerConfig
 
 
-def get_base_dir() -> Path:
+def get_config_path(file_name: Literal["config.yaml", ".env"]) -> Path:
     """
-    Get the base directory of the project.
+    Get the path to the config file.
 
     Returns:
-        Path: The base directory of the project.
+        Path: The path to the config file.
     """
-
     current_dir = Path(__file__).resolve()
-    while (
-        current_dir.parent != current_dir
-        and not (current_dir / "config.yaml").exists()
-    ):
+    while current_dir.parent != current_dir and not (current_dir / file_name).exists():
         current_dir = current_dir.parent
-    return current_dir
-
-
-BASE_DIR = get_base_dir()
+    print(current_dir / file_name)
+    return current_dir / file_name
 
 
 # Добавляем модели для других секций конфига, если они есть в config.yaml
@@ -112,30 +105,18 @@ class BackendConfig(BaseModel):
     api: ApiConfig = Field(default_factory=ApiConfig)
 
 
-class MainConfig(YamlBaseSettings):
+class MainConfig(BaseModel):
     """
-    Main application configuration.
+    Main application configuration model.
 
-    This class loads application settings from `config.yaml` and `.env` files.
-    It uses Pydantic-settings to manage hierarchical configuration.
+    This class defines the structure of the application's configuration.
+    It is populated manually from YAML and .env files for full control.
 
     Attributes:
         frontend (FrontendConfig): Frontend specific settings.
         backend (BackendConfig): Backend specific settings, including logger,
         database, and API.
     """
-
-    model_config = SettingsConfigDict(
-        # Загружаем статический YAML из корня проекта
-        yaml_file=BASE_DIR / "config.yaml",
-        yaml_file_encoding="utf-8",
-        # Затем загружаем .env из корня проекта (для секретов)
-        env_file=BASE_DIR / ".env",
-        env_file_encoding="utf-8",
-        # Общий префикс для переменных окружения приложения
-        env_prefix="APP_",
-        env_nested_delimiter="__",
-    )
 
     frontend: FrontendConfig = Field(default_factory=FrontendConfig)
     backend: BackendConfig = Field(default_factory=BackendConfig)

--- a/backend/tests/config/test_config.py
+++ b/backend/tests/config/test_config.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from src.config import get_main_config
+
+get_main_config.cache_clear()
+
+TEST_PORT = 8000
+ENV_BACKEND_DATABASE_HOST = "BACKEND__DATABASE__HOST"
+ENV_BACKEND_API_PORT = "BACKEND__API__PORT"
+
+
+@pytest.fixture
+def mock_config_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
+    """
+    Fixture to create temporary config files and mock get_config_path.
+    """
+    yaml_content = f"""
+    backend:
+      api:
+        host: "0.0.0.0"
+        port: {TEST_PORT}
+      database:
+        host: "yaml_db_host"
+        port: 5432
+    """
+    env_file_content = f'{ENV_BACKEND_DATABASE_HOST}="env_db_host"'
+
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(yaml_content)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(env_file_content)
+
+    def mock_get_path(file_name: str) -> Path:
+        return tmp_path / file_name
+
+    monkeypatch.setattr("src.config.get_config_path", mock_get_path)
+
+    get_main_config.cache_clear()
+    return tmp_path
+
+
+def test_load_from_yaml(mock_config_files: Path, monkeypatch: MonkeyPatch) -> None:
+    """
+    Tests that configuration is correctly loaded from the YAML file.
+    """
+
+    # delete system environment variables
+    monkeypatch.delenv(ENV_BACKEND_DATABASE_HOST, raising=False)
+    monkeypatch.delenv(ENV_BACKEND_API_PORT, raising=False)
+
+    (mock_config_files / ".env").unlink()
+
+    config = get_main_config()
+
+    assert config.backend.api.port == TEST_PORT
+    assert config.backend.database.host == "yaml_db_host"
+
+
+def test_override_from_env_file(mock_config_files: Path, monkeypatch: MonkeyPatch) -> None:  # noqa: ARG001
+    """
+    Tests that .env variables override YAML configuration.
+    """
+    monkeypatch.delenv(ENV_BACKEND_DATABASE_HOST, raising=False)
+    config = get_main_config()
+    assert config.backend.database.host == "env_db_host"
+
+
+def test_override_from_system_env(mock_config_files: Path, monkeypatch: MonkeyPatch) -> None:  # noqa: ARG001
+    """
+    Tests that system environment variables override both .env and YAML.
+    """
+    test_db_host = "system_env_db_host"
+    test_port = 9999
+    monkeypatch.setenv(ENV_BACKEND_DATABASE_HOST, test_db_host)
+    monkeypatch.setenv(ENV_BACKEND_API_PORT, str(test_port))
+
+    config = get_main_config()
+
+    assert config.backend.database.host == test_db_host
+    assert config.backend.api.port == test_port
+
+
+def test_yaml_not_found_raises_error(mock_config_files: Path) -> None:
+    """
+    Tests that a FileNotFoundError is raised if config.yaml is missing.
+    """
+    (mock_config_files / "config.yaml").unlink()
+
+    with pytest.raises(FileNotFoundError):
+        get_main_config()
+
+
+@patch("src.config._load_yaml_config")
+def test_get_main_config_is_cached(mock_load_yaml: MagicMock) -> None:
+    """
+    Tests that the get_main_config function is cached.
+    """
+    with patch("src.config.get_config_path"):
+        mock_load_yaml.return_value = {}
+
+        for _ in range(3):
+            get_main_config()
+
+        mock_load_yaml.assert_called_once()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -78,6 +78,30 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/4c/7c991e080e106d854809030d8584e15b2e996e26f16aee6d757e387bc17d/asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851", size = 957746 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/64/9d3e887bb7b01535fdbc45fbd5f0a8447539833b97ee69ecdbb7a79d0cb4/asyncpg-0.30.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c902a60b52e506d38d7e80e0dd5399f657220f24635fee368117b8b5fce1142e", size = 673162 },
+    { url = "https://files.pythonhosted.org/packages/6e/eb/8b236663f06984f212a087b3e849731f917ab80f84450e943900e8ca4052/asyncpg-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aca1548e43bbb9f0f627a04666fedaca23db0a31a84136ad1f868cb15deb6e3a", size = 637025 },
+    { url = "https://files.pythonhosted.org/packages/cc/57/2dc240bb263d58786cfaa60920779af6e8d32da63ab9ffc09f8312bd7a14/asyncpg-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c2a2ef565400234a633da0eafdce27e843836256d40705d83ab7ec42074efb3", size = 3496243 },
+    { url = "https://files.pythonhosted.org/packages/f4/40/0ae9d061d278b10713ea9021ef6b703ec44698fe32178715a501ac696c6b/asyncpg-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1292b84ee06ac8a2ad8e51c7475aa309245874b61333d97411aab835c4a2f737", size = 3575059 },
+    { url = "https://files.pythonhosted.org/packages/c3/75/d6b895a35a2c6506952247640178e5f768eeb28b2e20299b6a6f1d743ba0/asyncpg-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5712350388d0cd0615caec629ad53c81e506b1abaaf8d14c93f54b35e3595a", size = 3473596 },
+    { url = "https://files.pythonhosted.org/packages/c8/e7/3693392d3e168ab0aebb2d361431375bd22ffc7b4a586a0fc060d519fae7/asyncpg-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db9891e2d76e6f425746c5d2da01921e9a16b5a71a1c905b13f30e12a257c4af", size = 3641632 },
+    { url = "https://files.pythonhosted.org/packages/32/ea/15670cea95745bba3f0352341db55f506a820b21c619ee66b7d12ea7867d/asyncpg-0.30.0-cp312-cp312-win32.whl", hash = "sha256:68d71a1be3d83d0570049cd1654a9bdfe506e794ecc98ad0873304a9f35e411e", size = 560186 },
+    { url = "https://files.pythonhosted.org/packages/7e/6b/fe1fad5cee79ca5f5c27aed7bd95baee529c1bf8a387435c8ba4fe53d5c1/asyncpg-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:9a0292c6af5c500523949155ec17b7fe01a00ace33b68a476d6b5059f9630305", size = 621064 },
+    { url = "https://files.pythonhosted.org/packages/3a/22/e20602e1218dc07692acf70d5b902be820168d6282e69ef0d3cb920dc36f/asyncpg-0.30.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05b185ebb8083c8568ea8a40e896d5f7af4b8554b64d7719c0eaa1eb5a5c3a70", size = 670373 },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/0cf269a9d647852a95c06eb00b815d0b95a4eb4b55aa2d6ba680971733b9/asyncpg-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c47806b1a8cbb0a0db896f4cd34d89942effe353a5035c62734ab13b9f938da3", size = 634745 },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/a4f31bf358ce8491d2a31bfe0d7bcf25269e80481e49de4d8616c4295a34/asyncpg-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b6fde867a74e8c76c71e2f64f80c64c0f3163e687f1763cfaf21633ec24ec33", size = 3512103 },
+    { url = "https://files.pythonhosted.org/packages/96/19/139227a6e67f407b9c386cb594d9628c6c78c9024f26df87c912fabd4368/asyncpg-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46973045b567972128a27d40001124fbc821c87a6cade040cfcd4fa8a30bcdc4", size = 3592471 },
+    { url = "https://files.pythonhosted.org/packages/67/e4/ab3ca38f628f53f0fd28d3ff20edff1c975dd1cb22482e0061916b4b9a74/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9110df111cabc2ed81aad2f35394a00cadf4f2e0635603db6ebbd0fc896f46a4", size = 3496253 },
+    { url = "https://files.pythonhosted.org/packages/ef/5f/0bf65511d4eeac3a1f41c54034a492515a707c6edbc642174ae79034d3ba/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04ff0785ae7eed6cc138e73fc67b8e51d54ee7a3ce9b63666ce55a0bf095f7ba", size = 3662720 },
+    { url = "https://files.pythonhosted.org/packages/e7/31/1513d5a6412b98052c3ed9158d783b1e09d0910f51fbe0e05f56cc370bc4/asyncpg-0.30.0-cp313-cp313-win32.whl", hash = "sha256:ae374585f51c2b444510cdf3595b97ece4f233fde739aa14b50e0d64e8a7a590", size = 560404 },
+    { url = "https://files.pythonhosted.org/packages/c8/a4/cec76b3389c4c5ff66301cd100fe88c318563ec8a520e0b2e792b5b84972/asyncpg-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:f59b430b8e27557c3fb9869222559f7417ced18688375825f8f12302c34e915e", size = 621623 },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -98,14 +122,16 @@ dependencies = [
     { name = "aerich" },
     { name = "aiosqlite" },
     { name = "apscheduler" },
+    { name = "asyncpg" },
     { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "lxml" },
     { name = "pydantic" },
-    { name = "pydantic-settings-yaml" },
     { name = "pytelegrambotapi" },
+    { name = "pyyaml" },
+    { name = "tomlkit" },
     { name = "tortoise-orm" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -125,14 +151,16 @@ requires-dist = [
     { name = "aerich", specifier = ">=0.9.0" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "apscheduler", specifier = ">=3.11.0" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "lxml", specifier = ">=5.2.2" },
     { name = "pydantic", specifier = ">=2.11.5" },
-    { name = "pydantic-settings-yaml", specifier = ">=0.2.0" },
     { name = "pytelegrambotapi", specifier = ">=4.27.0" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "tomlkit", specifier = ">=0.13.0" },
     { name = "tortoise-orm", specifier = ">=0.25.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.1" },
 ]
@@ -515,33 +543,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356 },
-]
-
-[[package]]
-name = "pydantic-settings-yaml"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic-settings" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/b5/0de91f5e0d23c0301e44029d5f64a32127f89611acc0a11fc55eb2bc90d1/pydantic_settings_yaml-0.2.0.tar.gz", hash = "sha256:ee3c679ecd04ae045de100458387ff92bb54b435807ca8ac0726c141f63b1c8d", size = 7432 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl", hash = "sha256:e5e3a4866d124cc03bff5cca968455ce658f0382a8287c4b14e5fe91a2d6e2ef", size = 6627 },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -759,6 +760,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901 },
 ]
 
 [[package]]


### PR DESCRIPTION
---

### Context

The standard loading mechanisms in Pydantic (`BaseSettings`) and `pydantic-settings-yaml` (`YamlBaseSettings`) did not support the required configuration hierarchy. Settings from `config.yaml` and the `.env` file did not layer with the correct priority; instead, they were mutually exclusive.

This PR introduces a custom loading mechanism to resolve this issue by establishing a clear hierarchy: **Environment Variables > .env file > config.yaml**.

---

### Description

- A custom configuration loader is implemented in `src/config/__init__.py`. It sequentially reads base settings from `config.yaml` and then overrides them with values from the `.env` file and system environment variables.
- Configuration models in `src/config/config.py` now inherit from `pydantic.BaseModel` to work with the new loader.
- Test coverage in `tests/config/test_config.py` has been significantly expanded to verify all levels of loading priority (YAML, .env, and environment variables).
- The `pyyaml` dependency has been added to `pyproject.toml` for parsing `config.yaml`.

---

### How to test

No manual testing is required. A successful CI pipeline is sufficient for verification.