### PR TITLE
feat(navigation): make job card a navigable link

### DIFF
--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { Job } from '@/services/jobService.types';
 
 type JobCardProps = {
@@ -7,10 +8,10 @@ type JobCardProps = {
 
 const JobCard: React.FC<JobCardProps> = ({ job }) => {
   return (
-    <div>
-      <h2>{job.title}</h2>
-      <p>{job.company}</p>
-    </div>
+    <Link href={`/jobs/${job.id}`} className="block p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+      <h2 className="text-xl font-semibold">{job.title}</h2>
+      <p className="text-gray-600">{job.company}</p>
+    </Link>
   );
 };
 

--- a/frontend/tests/components/JobCard.test.tsx
+++ b/frontend/tests/components/JobCard.test.tsx
@@ -11,12 +11,18 @@ describe('JobCard component', () => {
     company: 'Innovate Inc.',
     url: 'https://example.com/job/1',
     created_at: new Date().toISOString(),
+    description: 'A detailed job description.', // Добавляем недостающее свойство
   };
 
-  it('should render the job title and company name', () => {
+  it('should render the job title, company name, and be a valid link', () => {
     render(<JobCard job={mockJob} />);
 
+    // Проверяем, что текст на месте
     expect(screen.getByText('Senior Software Engineer')).toBeInTheDocument();
     expect(screen.getByText('Innovate Inc.')).toBeInTheDocument();
+
+    // Проверяем, что это ссылка и она ведет на правильный URL
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toHaveAttribute('href', `/jobs/${mockJob.id}`);
   });
 }); 


### PR DESCRIPTION
---

### Context

This pull request enables navigation from the main job list to the job detail page. It makes the `JobCard` component a clickable link, which is a crucial step for user interaction.

---

### Description

This PR implements the navigation functionality as outlined in task 1.5.1 of the project plan.

-   **Component Update:** The `JobCard` component in `frontend/src/components/JobCard.tsx` has been wrapped with Next.js's `<Link>` component.
-   **Dynamic URL:** The link dynamically points to `/jobs/{job.id}`, ensuring correct routing for each specific job.
-   **TDD:** The corresponding test for `JobCard.test.tsx` has been updated to assert that the component now renders a valid `<a>` tag with the correct `href` attribute. This ensures the component's contract as a navigable element is always met.
-   **Styling:** Added basic hover effects to the card to improve UX and visually indicate that it is clickable.

---

### How to test

No manual testing is required. The updated unit test for the `JobCard` component, which is part of the CI pipeline, is sufficient for verification.

---